### PR TITLE
Change download url

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,10 +37,10 @@ class jq (
     default => $ensure,
   }
 
-  if $ensure == present or $ensure == $latest {
-    $url = 'http://stedolan.github.io/jq/download/linux64/jq'
-  } else {
-    $url = "http://stedolan.github.io/jq/download/linux64/jq-${version}/jq"
+  if versioncmp("$version", '1.4') > 0 {
+    $url = "https://github.com/stedolan/jq/releases/download/jq-${version}/jq-linux64"
+  }else{
+    $url = "https://github.com/stedolan/jq/releases/download/jq-${version}/jq-linux-x86_64"
   }
 
   $binary_path = "/usr/local/bin/jq-${version}"


### PR DESCRIPTION
Fixes #2

Download url has been changed as below.
https://stedolan.github.io/jq/download/

Example of hiera:
```yaml
jq::ensure: latest
jq::latest: 1.5
```
